### PR TITLE
correcting for gulp build to work on Win 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "browserify-shim": "^3.8.2",
     "coffeeify": "~1.0.0",
     "gulp": "^3.8.11",
-    "gulp-autoprefixer": "^2.1.0",
+    "gulp-autoprefixer": "^3.1.1",
     "gulp-changed": "^1.1.1",
     "gulp-exec": "^2.1.2",
     "gulp-filesize": "0.0.6",


### PR DESCRIPTION
This is the fix for the issue submitted for gulp-autoprefixer failing on the `gulp build` step in the Readme.