### PR TITLE
HYP 11: add single gulp command to start openfin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Desktop.ini
 build
 node_modules
 bower_components
+.vscode

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NB: (the additional 'sudo' command may be required, eg. 'sudo npm install' at wh
  
 The app runs locally on a simple Node server and the code is compiled using [Gulp](http://gulpjs.com/) as a build tool. 
 
-###Run app locally
+### Run app locally
 The app must first be compiled. This only needs to be done the first time the app is run, but the app will need to be recompiled if modifications are made to the code.
 
 Open two terminal windows and in both change the directory to the 'Hyperblotter' folder.
@@ -51,17 +51,24 @@ Once installed, in the first terminal window, build the project from the source 
 ```
 $ gulp build
 ```
-Then start the local Node server.
+Then start the app.
 
 NB for a production Node app this would require hosting remotely on Heroku, AWS or a similar platform. OpenFin is not designed to install apps locally.
 
 ```
+$ gulp start
+```
+`gulp start` starts the server and launches OpenFin.
+
+An executable should now be created and launched. 
+
+### Start only the server
+You can choose to start the server alone by running
+```
 $ gulp server
 ```
-Once the message 'Express server is listening on port 5001' is shown in the terminal open the second terminal window (leave the first terminal window open, closing it will close the server). Launch Openfin.
 
-```
+If you've started your server and you want to start OpenFin you can do so by running
+ ```
 $ gulp openfin
 ```
-An executable should now be created an launch the Hyperblotter toolbar. 
- 

--- a/gulp/tasks/openfin.js
+++ b/gulp/tasks/openfin.js
@@ -1,15 +1,17 @@
-var  gulp   = require('gulp')
-    ,gutil = require("gulp-util")
-    ,exec = require("gulp-exec")
-    ,q = require('q')
-    ,openfinLauncher = require('openfin-launcher')
-    //,openfinConfigBuilder = require('openfin-config-builder')
-    ,nodemon = require('nodemon')
-    ,src  = require('../config').js
-    ,path = require('path')
-    ,userName =   (process && process.env && process.env['USERPROFILE'] ? process.env['USERPROFILE'].split(path.sep)[2] : null)
-    ,rootDir =    (process && process.cwd()  ? process.cwd() : null);
- 
+var gulp = require('gulp'),
+  gutil = require("gulp-util"),
+  exec = require("gulp-exec"),
+  sequence = require("gulp-sequence"),
+  q = require('q'),
+  openfinLauncher = require('openfin-launcher')
+  //,openfinConfigBuilder = require('openfin-config-builder')
+  ,
+  nodemon = require('nodemon'),
+  src = require('../config').js,
+  path = require('path'),
+  userName = (process && process.env && process.env['USERPROFILE'] ? process.env['USERPROFILE'].split(path.sep)[2] : null),
+  rootDir = (process && process.cwd() ? process.cwd() : null);
+
 //gulp.task('openfin', function() {
 //  openfinLauncher.launchOpenFin({
 //      configPath: 'file:/' + path.resolve('app.json')
@@ -17,53 +19,52 @@ var  gulp   = require('gulp')
 //});
 
 /* Starts up theNode server - returning a promise so it may be chained in the 'openfin' task. */
-function startServerPromise(){
-    process.chdir(rootDir);
-    var defered = q.defer();
-    var _resolve = function(){
-            defered.resolve()
-    };
-    nodemon({
-        script: 'server.js'
-        , ext: 'js html'
-        , env: { 'NODE_ENV': 'development' }
-        , events: {
-            "start": _resolve()
-        }
-    });
-    return defered.promise;
+function startServerPromise() {
+  process.chdir(rootDir);
+  var defered = q.defer();
+  var _resolve = function() {
+    defered.resolve()
+  };
+  nodemon({
+    script: 'server.js',
+    ext: 'js html',
+    env: { 'NODE_ENV': 'development' },
+    events: {
+      "start": _resolve()
+    }
+  });
+  return defered.promise;
 }
 
 function openfinLaunch() {
-    try {
-        var _dir = 'C:\\Users\\' + userName + '\\AppData\\Local\\OpenFin'
-        process.chdir(_dir);
-    }catch(err){
-        //--
-    }
+  try {
+    var _dir = 'C:\\Users\\' + userName + '\\AppData\\Local\\OpenFin'
+    process.chdir(_dir);
+  } catch (err) {
+    //--
+  }
 
-    openfinLauncher.launchOpenFin({
-        // Launch a locally hosted Node application.
-        configPath: 'http://localhost:5001/app.json'
+  openfinLauncher.launchOpenFin({
+      // Launch a locally hosted Node application.
+      configPath: 'http://localhost:5001/app.json'
     })
-        .then(function () {
-            console.log('OpenFin launched!');
-        })
-        .fail(function (error) {
-            console.log('Error opening OpenFin!', error);
-        });
+    .then(function() {
+      console.log('OpenFin launched!');
+    })
+    .fail(function(error) {
+      console.log('Error opening OpenFin!', error);
+    });
 }
 
 /* THIS IS THE MAIN CALL TO LAUNCH THE OPENFIN APP. */
 
 gulp.task('server', function() {
-    return startServerPromise()
-            .then(function(){console.log("Server now running - call 'gulp openfin'")});
+  return startServerPromise();
 });
 
 
 gulp.task('openfin', function() {
-            return openfinLaunch();
+  return openfinLaunch();
 });
 
-
+gulp.task('start', sequence('server', 'openfin'));

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "express": "^4.13.3",
+    "gulp-sequence": "^0.4.6",
     "jquery": "~2.1.0",
     "underscore": "^1.8.3",
     "webpack": "1.12.11"


### PR DESCRIPTION
Ticket No: HYP 11
Ticket Url: https://appoji.jira.com/projects/HYP/issues/HYP-11

Description: Starting OpenFin currently involve running two seperate gulp tasks 
`gulp server` and `gulp openfin`. This PR adds a single gulp task to start Open Fin
`gulp start`