### PR TITLE
HYP 7 set runtime version to stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Desktop.ini
 build
 node_modules
 bower_components
+.vscode

--- a/app.json
+++ b/app.json
@@ -27,7 +27,7 @@
     },
     "runtime": {
         "arguments": "",
-        "version": "5.44.9.2"
+        "version": "6.49.18.41"
     },
     "appAssets": [
             {

--- a/app.json
+++ b/app.json
@@ -27,7 +27,7 @@
     },
     "runtime": {
         "arguments": "",
-        "version": "6.49.18.41"
+        "version": "stable"
     },
     "appAssets": [
             {


### PR DESCRIPTION
Ticket No: HYP 7
Ticket Url: https://appoji.jira.com/projects/HYP/issues/HYP-7

Description: The app.json runtime version field specifies what runtime version of OpenFin Hyperblotter runs against. This PR updates that field to 6.49.18.41,