### PR TITLE
Hyp 19 reactify to babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ If yarn is not installed, install from [here](https://yarnpkg.com/lang/en/docs/i
 $ npm install -g yarn
 ```
 
-Install dependencies using yarn:
+### Run app locally
+
+Open a terminal window and change the directory to the 'Hyperblotter' folder.
+
+```
+$ cd Hyperblotter
+```
+
+In the terminal window, install dependencies using yarn:
 
 ```
 $ yarn install
@@ -44,23 +52,15 @@ NB: (the additional 'sudo' command may be required, eg. 'sudo yarn install' at w
 
 The app runs locally on a simple Node server and the code is compiled using [Gulp](http://gulpjs.com/) as a build tool.
 
-### Run app locally
-
 The app must first be compiled. This only needs to be done the first time the app is run, but the app will need to be recompiled if modifications are made to the code.
 
-Open a terminal windows and change the directory to the 'Hyperblotter' folder.
-
-```
-$ cd Hyperblotter
-```
-
-In the terminal window, build the project from the source files.
+In the terminal, build the project from the source files:
 
 ```
 $ yarn build
 ```
 
-Then start the app.
+Then start the app:
 
 NB for a production Node app this would require hosting remotely on Heroku, AWS or a similar platform. OpenFin is not designed to install apps locally.
 

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -8,22 +8,22 @@
    See browserify.bundleConfigs in gulp/config.js
 */
 
-var browserify   = require('browserify');
-var browserSync  = require('browser-sync');
-var watchify     = require('watchify');
-var mergeStream  = require('merge-stream');
+var browserify = require('browserify');
+var browserSync = require('browser-sync');
+var watchify = require('watchify');
+var mergeStream = require('merge-stream');
 var bundleLogger = require('../util/bundleLogger');
-var gulp         = require('gulp');
+var gulp = require('gulp');
 var handleErrors = require('../util/handleErrors');
-var source       = require('vinyl-source-stream');
-var config       = require('../config').browserify;
-var _            = require('lodash');
+var source = require('vinyl-source-stream');
+var config = require('../config').browserify;
+var _ = require('lodash');
 
 var browserifyTask = function(devMode) {
 
   var browserifyThis = function(bundleConfig) {
 
-    if(devMode) {
+    if (devMode) {
       // Add watchify args and debug (sourcemaps) option
       _.extend(bundleConfig, watchify.args, { debug: true });
       // A watchify require/external bug that prevents proper recompiling,
@@ -34,7 +34,7 @@ var browserifyTask = function(devMode) {
 
     console.log('the browser bundle', bundleConfig);
     var b = browserify(bundleConfig);
-    b.transform('reactify', {es6: true});
+    b.transform('babelify', { presets: ["es2015", "react"] });
 
     var bundle = function() {
       // Log when bundling starts
@@ -55,7 +55,7 @@ var browserifyTask = function(devMode) {
         }));
     };
 
-    if(devMode) {
+    if (devMode) {
       // Wrap with watchify and rebundle on changes
       b = watchify(b);
       // Rebundle on update
@@ -64,10 +64,10 @@ var browserifyTask = function(devMode) {
     } else {
       // Sort out shared dependencies.
       // b.require exposes modules externally
-      if(bundleConfig.require) b.require(bundleConfig.require);
+      if (bundleConfig.require) b.require(bundleConfig.require);
       // b.external excludes modules from the bundle, and expects
       // they'll be available externally
-      if(bundleConfig.external) b.external(bundleConfig.external);
+      if (bundleConfig.external) b.external(bundleConfig.external);
     }
 
     return bundle();

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     }
   },
   "devDependencies": {
-    "babelify": "^6.4.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babelify": "^7.2.0",
     "browser-sync": "^2.7.1",
     "browserify": "^9.0.3",
     "browserify-shim": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "pretty-hrtime": "~1.0.0",
     "q": "^1.4.1",
     "react": "^0.13.1",
-    "reactify": "^1.1.0",
     "require-dir": "^0.3.0",
     "socket.io-client": "^1.3.5",
     "vinyl-source-stream": "~1.0.0",

--- a/src/javascript/streams/socket.js
+++ b/src/javascript/streams/socket.js
@@ -1,64 +1,69 @@
 var EventEmitter = require('events').EventEmitter,
-    _ = require('underscore'),
-    io = require('socket.io-client'),
-    socket = io('http://nerfapi-openfin.rhcloud.com:8000');
+  _ = require('underscore'),
+  io = require('socket.io-client'),
+  socket = io('http://nerfapi-openfin.rhcloud.com:8000');
 
-socket.on('connect', function (plop) {
-	console.log('connected');
+socket.on('connect', function(plop) {
+  console.log('connected');
 })
 var socketStream = Object.create(EventEmitter.prototype),
-	that = this;
+  that = this;
 
 function send(data) {
-	console.log('sending data', data);
-	socket.emit('openfin:socketmesage', data);
+  console.log('sending data', data);
+  socket.emit('openfin:socketmesage', data);
 };
+
 function sendStuff(stuff) {
-	console.log('stuff was sent!', stuff);
+  console.log('stuff was sent!', stuff);
 }
+
 function join(user) {
-	user.id = socket.id;
-	send({
-		message:'user:join',
-		data:user
-	});
-	rollCall();
+  user.id = socket.id;
+  send({
+    message: 'user:join',
+    data: user
+  });
+  rollCall();
 }
+
 function respondToRollcall(user) {
-	console.log('respondToRollcall', user);
-	send({
-		message:'user:rollcall:respond',
-		data: user
-	});
+  console.log('respondToRollcall', user);
+  send({
+    message: 'user:rollcall:respond',
+    data: user
+  });
 }
+
 function rollCall() {
-	send({
-		message:'user:rollcall'
-	});
+  send({
+    message: 'user:rollcall'
+  });
 }
 
 function sendSymbol(origName, symbol, destName) {
-	send({
-		message:'notification:symbol',
-		data: {
-			destName:destName,
-			origName:origName,
-			symbol:symbol
-		}
-	});
+  send({
+    message: 'notification:symbol',
+    data: {
+      destName: destName,
+      origName: origName,
+      symbol: symbol
+    }
+  });
 }
 
 //this sucks
-socket.on('openfin:socketmesage', function(package) {
-	if(package.message === 'user:join') {
-		socketStream.emit('user:joined', package.data);
-	} else if(package.message === 'user:rollcall') {
-		socketStream.emit('user:rollcall');
-	} else if(package.message === 'user:rollcall:respond') {
-		socketStream.emit('user:joined', package.data);
-	} else if(package.message === 'notification:symbol') {
-		socketStream.emit('notification:symbol', package.data);
-	}
+// changed package to packageObject as 'package' is a reserved word in strict mode
+socket.on('openfin:socketmesage', function(packageObject) {
+  if (packageObject.message === 'user:join') {
+    socketStream.emit('user:joined', packageObject.data);
+  } else if (packageObject.message === 'user:rollcall') {
+    socketStream.emit('user:rollcall');
+  } else if (packageObject.message === 'user:rollcall:respond') {
+    socketStream.emit('user:joined', packageObject.data);
+  } else if (packageObject.message === 'notification:symbol') {
+    socketStream.emit('notification:symbol', packageObject.data);
+  }
 });
 
 socketStream.sendStuff = sendStuff;


### PR DESCRIPTION
This PR switches from reactify to babel in the build process. This is to take advantage of babel's better JSX and JS transpiling process.