### PR TITLE
RUN-4879 Fix problem with multiple shadow roots creation

### DIFF
--- a/src/javascript/vendor/openfin_hypergrid_polymer/fin-hypergrid.dev.html
+++ b/src/javascript/vendor/openfin_hypergrid_polymer/fin-hypergrid.dev.html
@@ -10326,8 +10326,10 @@ scope.styleResolver = styleResolver;
      */
     shadowFromTemplate: function(template) {
       if (template) {
-        // make a shadow root
-        var root = this.createShadowRoot();
+        var root = this.shadowRoot;
+        if (root === null)
+          // make a shadow root
+          root = this.createShadowRoot();
         // stamp template
         // which includes parsing and applying MDV bindings before being
         // inserted (to avoid {{}} in attribute values)


### PR DESCRIPTION
In v10 runtime hyperblotter doesn't work correctly because support for multiple shadow roots was removed from chromium. This PR fixes hyperblotter.
For more info see:
https://www.chromestatus.com/features/4668884095336448
https://bugs.chromium.org/p/chromium/issues/detail?id=489947